### PR TITLE
Update tutor names in README for semester 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Members of the development team will take an active role in bringing this projec
 | Wendy Dimond   | Client |
 | Paul Dowden    | Client |
 | Jie Li         | Handover Developer |
-| Anthony Troy   | Tutor  |
-| David Retter   | Tutor  |
+| Brenton Smith  | Tutor  |
+| Huy Pham       | Other Tutorial Tutor  |
 
 
 ## Resources


### PR DESCRIPTION
This PR fixes up the names of tutors for Semester 2 - I've included the other two teams tutor as well under a different label for completeness.

Closes #46.